### PR TITLE
feat: Add "how we met" field to contacts

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -34,7 +34,7 @@ class Contact extends Model implements CalendarInterface
         'custom_id',
         'nickname',
         'active',
-        'first_met',
+        'how_we_met',
         'note',
         'died_at',
         'died_from',

--- a/database/migrations/2026_01_29_072307_rename_first_met_in_contacts_table.php
+++ b/database/migrations/2026_01_29_072307_rename_first_met_in_contacts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            $table->renameColumn('first_met', 'how_we_met');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            $table->renameColumn('how_we_met', 'first_met');
+        });
+    }
+};

--- a/resources/lang/en/ui.php
+++ b/resources/lang/en/ui.php
@@ -81,7 +81,7 @@ return [
     'logs' => 'Logs',
     'notification_settings' => 'Notification settings',
     'update' => 'Update',
-    'first_met' => 'First met',
+    'how_we_met' => 'How we met',
     'note' => 'Note',
     'died_at' => 'Died at',
     'died_from' => 'Died from',

--- a/resources/views/partials/contact/edit.blade.php
+++ b/resources/views/partials/contact/edit.blade.php
@@ -101,7 +101,7 @@
     </div>
 </div>
 
-{!! \App\Helpers\Form::textarea('first_met', trans('ui.first_met'), $contact->first_met) !!}
+{!! \App\Helpers\Form::textarea('how_we_met', trans('ui.how_we_met'), $contact->how_we_met) !!}
 
 {!! \App\Helpers\Form::textarea('note', trans('ui.note'), $contact->note) !!}
 

--- a/resources/views/partials/contact/show.blade.php
+++ b/resources/views/partials/contact/show.blade.php
@@ -8,6 +8,8 @@
         <strong>Anrede: </strong> {{ $contact->salutation }}<br>
         <strong>Geburtstag: </strong> {{ $contact->formatted_date_of_birth }}
         <br>
+        <strong>{{ trans('ui.how_we_met') }}: </strong> {{ $contact->how_we_met }}
+        <br>
         @if (Auth::user()->hasPermissionTo('view addresses'))
             <strong>Adressen</strong>:
             @include('partials.contact.additional.addresses', ['addresses' => $contact->addresses])


### PR DESCRIPTION
This change renames the existing `first_met` field to `how_we_met` to improve clarity and makes it visible on the contact detail page. The change includes a database migration, model and view updates, and a language file update.

Fixes #7

---
*PR created automatically by Jules for task [5368074190768781758](https://jules.google.com/task/5368074190768781758) started by @alexanderglueck*